### PR TITLE
feat: Improve garbage collection in go-redis lib v8

### DIFF
--- a/command.go
+++ b/command.go
@@ -1161,6 +1161,34 @@ func (cmd *BoolSliceCmd) readReply(rd *proto.Reader) error {
 
 //------------------------------------------------------------------------------
 
+type CustomCmd struct {
+	baseCmd
+
+	customReader func(*proto.Reader) error
+}
+
+func NewCustomCmd(ctx context.Context, customReader func(reader *proto.Reader) error, args ...interface{}) *CustomCmd {
+	return &CustomCmd{
+		baseCmd: baseCmd{
+			ctx:  ctx,
+			args: args,
+		},
+		customReader: customReader,
+	}
+}
+
+var _ Cmder = (*CustomCmd)(nil)
+
+func (cmd *CustomCmd) String() string {
+	return cmdString(cmd, cmd.customReader)
+}
+
+func (cmd *CustomCmd) readReply(rd *proto.Reader) error {
+	return cmd.customReader(rd)
+}
+
+//------------------------------------------------------------------------------
+
 type StringStringMapCmd struct {
 	baseCmd
 

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -2,6 +2,7 @@ package proto_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 
@@ -40,6 +41,29 @@ func TestReader_ReadLine(t *testing.T) {
 
 	if bytes.Compare(read, original[:len(original)-2]) != 0 {
 		t.Errorf("Values must be equal: %d expected %d", len(read), len(original[:len(original)-2]))
+	}
+}
+
+func TestReader_BufferedRead(t *testing.T) {
+	srcStr := "abcdef"
+	readerBuf := []byte(fmt.Sprintf("$%v\r\n%v\r\n", len(srcStr), srcStr))
+	r := proto.NewReader(bytes.NewReader(readerBuf))
+
+	buf := make([]byte, 100)
+	strLen, err := r.ReadStringBuffered(buf)
+	if err != nil {
+		t.Errorf("Should be no error: %v", err)
+		return
+	}
+	if strLen != len(srcStr) {
+		t.Errorf("Resulting string length should be equal to %v, actual %v", len(srcStr), strLen)
+		return
+	}
+
+	resultStr := string(buf[:strLen])
+	if resultStr != srcStr {
+		t.Errorf("Expected string '%v', actual '%v'", srcStr, resultStr)
+		return
 	}
 }
 


### PR DESCRIPTION
1. Added interface method with exposed reader so lib user can deserialize redis response directly to dest structure
2. Added buffered read method for internal reader to avoid internal buffer allocations

SDB-2817